### PR TITLE
fix: add sub app style to document

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /test/fixtures/**/.umi
 /test/fixtures/**/.umi-production
 .idea/
+.cache/
+.umi/
+.umi-production/
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ umi dev
 - ✔︎ 父子应用通讯
 - ✔︎ 运行时配置 `bootstrap()`、`mount()` 和 `unmount()`
 - ✔︎ HTML Entry
-- ✔ 预加载
+- ✔ js/css 预加载
 
 ## TODO
 
@@ -88,7 +88,7 @@ export default {
       '@umijs/plugin-qiankun/master',
       {
         // 注册子应用信息
-        apps: [
+        subAppConfig: [
           {
             // 唯一 id，传给 qiankun
             name: 'app1',
@@ -104,8 +104,8 @@ export default {
             entry: '/path/to/app/index.html',
           },
         ],
-        // JS 沙箱（暂不支持配置）
-        jsSandBox: false,
+        jsSandBox: true, // 是否启用 js 沙箱，默认为 false
+        prefetch: true, // 是否启用 prefetch 特性，默认为 true
       },
     ],
   ],
@@ -118,11 +118,12 @@ export default {
 
 ```js
 export default {
+  base: `/${appName}`, // 应用的 routerBase，默认为 package.json 中的 name 字段
   plugins: [
     [
       '@umijs/plugin-qiankun/slave',
       {
-        mountElementId: 'app-root',
+        mountElementId: 'app-root', // 子应用需挂载到哪个节点，默认为 #app-root
       },
     ],
   ],

--- a/examples/master/.umirc.js
+++ b/examples/master/.umirc.js
@@ -8,11 +8,13 @@ export default {
             name: 'app1',
             routerBase: '#/app1',
             entry: 'http://localhost:8002',
+            mountElementId: 'app-root',
           },
           {
             name: 'app2',
             routerBase: '#/app2',
             entry: 'http://localhost:8003',
+            mountElementId: 'app-root',
           },
         ],
         jsSandbox: true,

--- a/examples/master/.umirc.js
+++ b/examples/master/.umirc.js
@@ -15,6 +15,8 @@ export default {
             entry: 'http://localhost:8003',
           },
         ],
+        jsSandbox: true,
+        prefetch: true,
       },
     ],
   ],

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "qiankun": "^1.1.1"
   },
   "devDependencies": {
+    "@types/react-dom": "^16.8.4",
     "coveralls": "3",
     "father-build": "^1.2.0",
     "husky": "1",

--- a/src/common.ts
+++ b/src/common.ts
@@ -4,7 +4,7 @@
  */
 
 export const defaultMountContainerId = 'root-subapp';
-export const defaultMasterContainerId = 'root-master';
+export const defaultMasterRootId = 'root-master';
 export const defaultSlaveContainerId = 'root-slave';
 
 // @formatter:off

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,12 @@
+/**
+ * @author Kuitos
+ * @since 2019-06-20
+ */
+
+export const defaultMountContainerId = 'root-subapp';
+export const defaultMasterContainerId = 'root-master';
+export const defaultSlaveContainerId = 'root-slave';
+
+// @formatter:off
+export const noop = () => {};
+// @formatter:on

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -29,6 +29,6 @@ export default function(api: IApi, options: IOptions = {}) {
 window.g_rootExports = ${existsSync(rootExportsFile) ? `require('@/rootExports')` : `{}`};
     `.trim();
     api.writeTmpFile('qiankunRootExports.js', rootExports);
-    api.writeTmpFile('microApps.json', JSON.stringify(options.apps));
+    api.writeTmpFile('subAppsConfig.json', JSON.stringify(options));
   });
 }

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi-types';
+import { defaultMasterContainerId } from '../common';
 
 interface IApp {
   scripts?: [];
@@ -17,6 +18,7 @@ export default function(api: IApi, options: IOptions = {}) {
   api.modifyDefaultConfig(config => {
     return {
       ...config,
+      mountElementId: defaultMasterContainerId,
       disableGlobalVariables: true,
     };
   });

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -1,7 +1,7 @@
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi-types';
-import { defaultMasterContainerId } from '../common';
+import { defaultMasterRootId } from '../common';
 
 interface IApp {
   scripts?: [];
@@ -18,7 +18,7 @@ export default function(api: IApi, options: IOptions = {}) {
   api.modifyDefaultConfig(config => {
     return {
       ...config,
-      mountElementId: defaultMasterContainerId,
+      mountElementId: defaultMasterRootId,
       disableGlobalVariables: true,
     };
   });

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -3,12 +3,12 @@ import { join } from 'path';
 import { IApi } from 'umi-types';
 
 interface IApp {
-  scripts?: [],
-  styles?: [],
+  scripts?: [];
+  styles?: [];
 }
 
 interface IOptions {
-  apps?: IApp[],
+  apps?: IApp[];
 }
 
 export default function(api: IApi, options: IOptions = {}) {
@@ -31,4 +31,4 @@ window.g_rootExports = ${existsSync(rootExportsFile) ? `require('@/rootExports')
     api.writeTmpFile('qiankunRootExports.js', rootExports);
     api.writeTmpFile('microApps.json', JSON.stringify(options.apps));
   });
-};
+}

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -25,6 +25,18 @@ export function render(oldRender: typeof noop) {
           if (process.env.NODE_ENV === 'development') {
             console.info(`app ${name} loading ${loading}`);
           }
+
+          if (mountElementId) {
+            const container = document.getElementById(mountElementId);
+            if (container) {
+              const subApp = React.createElement('div', {
+                dangerouslySetInnerHTML: {
+                  __html: appContent,
+                },
+              });
+              ReactDOM.render(subApp, container);
+            }
+          }
         },
         props,
       };

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -1,5 +1,5 @@
-import apps from '@tmp/microApps.json';
 import '@tmp/qiankunRootExports.js';
+import subAppConfig from '@tmp/subAppsConfig.json';
 import { registerMicroApps, start } from 'qiankun';
 import { noop } from '../utils';
 
@@ -11,20 +11,22 @@ export function render(oldRender: typeof noop) {
     return location.hash.startsWith(routerBase);
   }
 
-  registerMicroApps(apps.map(({ name, entry, routerBase, ...props }) => {
-    return {
-      name,
-      entry,
-      activeRule: location => isAppActive(location, routerBase),
-      render: ({ appContent, loading }) => {
-        if (process.env.NODE_ENV === 'development') {
-          console.info(`app ${name} loading ${loading} with html content: ${appContent}`);
-        }
-      },
-      props,
-    };
-  }));
+  const { apps, jsSandbox = false, prefetch = true } = subAppConfig;
+  registerMicroApps(
+    apps.map(({ name, entry, routerBase, ...props }) => {
+      return {
+        name,
+        entry,
+        activeRule: location => isAppActive(location, routerBase),
+        render: ({ appContent, loading }) => {
+          if (process.env.NODE_ENV === 'development') {
+            console.info(`app ${name} loading ${loading} with html content: ${appContent}`);
+          }
+        },
+        props,
+      };
+    }),
+  );
 
-  // TODO 是否 jsSandbox 及 prefetch 应该从配置中取
-  start({ jsSandbox: true, prefetch: true });
+  start({ jsSandbox, prefetch });
 }

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -1,7 +1,9 @@
 import '@tmp/qiankunRootExports.js';
 import subAppConfig from '@tmp/subAppsConfig.json';
 import { registerMicroApps, start } from 'qiankun';
-import { noop } from '../utils';
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { defaultMountContainerId, noop } from '../common';
 
 export function render(oldRender: typeof noop) {
   oldRender();
@@ -13,14 +15,15 @@ export function render(oldRender: typeof noop) {
 
   const { apps, jsSandbox = false, prefetch = true } = subAppConfig;
   registerMicroApps(
-    apps.map(({ name, entry, routerBase, ...props }) => {
+    apps.map(({ name, entry, routerBase, mountElementId = defaultMountContainerId, ...props }) => {
+
       return {
         name,
         entry,
         activeRule: location => isAppActive(location, routerBase),
         render: ({ appContent, loading }) => {
           if (process.env.NODE_ENV === 'development') {
-            console.info(`app ${name} loading ${loading} with html content: ${appContent}`);
+            console.info(`app ${name} loading ${loading}`);
           }
         },
         props,

--- a/src/slave/index.ts
+++ b/src/slave/index.ts
@@ -1,6 +1,7 @@
 import assert from 'assert';
 import { join } from 'path';
 import { IApi } from 'umi-types';
+import { defaultSlaveContainerId } from '../common';
 
 interface IOptions {
   mountElementId?: string;
@@ -8,7 +9,7 @@ interface IOptions {
 
 export default function(api: IApi, options: IOptions = {}) {
   const lifecyclePath = require.resolve('./lifecycles');
-  const mountElementId = options.mountElementId || 'app-root';
+  const mountElementId = api.config.mountElementId || options.mountElementId || defaultSlaveContainerId;
 
   api.modifyDefaultConfig(memo => {
     const { name: pkgName } = require(join(api.cwd, 'package.json'));

--- a/src/slave/lifecycles.ts
+++ b/src/slave/lifecycles.ts
@@ -1,6 +1,6 @@
 // @ts-ignore
 import ReactDOM from 'react-dom';
-import { noop } from '../utils';
+import { noop } from '../common';
 
 type Defer = {
   promise: Promise<any>;
@@ -52,7 +52,10 @@ export function genMount() {
 
 export function genUnmount(mountElementId: string) {
   return async (...args: any[]) => {
-    ReactDOM.unmountComponentAtNode(document.getElementById(mountElementId));
+    const container = document.getElementById(mountElementId);
+    if (container) {
+      ReactDOM.unmountComponentAtNode(container);
+    }
     const slaveRuntime = getSlaveRuntime();
     if (slaveRuntime.unmount) await slaveRuntime.unmount(...args);
   };

--- a/src/slave/lifecycles.ts
+++ b/src/slave/lifecycles.ts
@@ -3,9 +3,9 @@ import ReactDOM from 'react-dom';
 import { noop } from '../utils';
 
 type Defer = {
-  promise: Promise<any>,
+  promise: Promise<any>;
   resolve(value?: any): void;
-}
+};
 
 // @ts-ignore
 const defer: Defer = {};

--- a/src/slave/runtimePlugin.ts
+++ b/src/slave/runtimePlugin.ts
@@ -3,9 +3,5 @@ import React from 'react';
 export function rootContainer(container: HTMLElement) {
   let value = (window as any).g_rootExports;
   const { Context } = require('@tmp/qiankunContext');
-  return React.createElement(
-    Context.Provider,
-    { value },
-    container,
-  );
+  return React.createElement(Context.Provider, { value }, container);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,0 @@
-/**
- * @author Kuitos
- * @since 2019-06-20
- */
-
-// @formatter:off
-export const noop = () => {};
-// @formatter:on

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -8,6 +8,7 @@ declare module '@tmp/subAppsConfig.json' {
     name: string;
     entry: string | { scripts: string[], styles: string[] };
     routerBase: string;
+    mountElementId: string;
   };
 
   const configuration: {

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,15 +3,19 @@
  * @since 2019-06-20
  */
 
-declare module '@tmp/microApps.json' {
-  type Apps = {
+declare module '@tmp/subAppsConfig.json' {
+  type App = {
     name: string;
     entry: string | { scripts: string[], styles: string[] };
     routerBase: string;
   };
 
-  const apps: Apps[];
-  export default apps;
+  const configuration: {
+    apps: App[];
+    jsSandbox: boolean;
+    prefetch: boolean;
+  };
+  export default configuration;
 }
 
 declare module '@tmp/qiankunRootExports.js';


### PR DESCRIPTION
1. 修复子应用样式丢失的问题
2. 支持子应用自定义 mountElementId，而不是必须在主应用中定义好相应容器节点
3. 支持 jsSandbox 及 prefetch 可配置

close https://github.com/umijs/umi/issues/2801
close https://github.com/umijs/umi/issues/2729#issuecomment-507534238