### PR TITLE
feat(master): 子应用的 history mode 跟主应用一致时，自动生成相应的路由配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ $ umi dev
 暂没很多时间深入，有需求的同学最好自己上。
 
 - [ ] 公共依赖加载策略
-- [ ] 支持 browserHistory
+- [x] 支持 browserHistory
 - [ ] 子应用嵌套
 - [ ] 子应用单独调试
 - [ ] 基于 Hooks 的父子应用通讯（需强制 external React 保证一个 React 实例）

--- a/README.md
+++ b/README.md
@@ -97,11 +97,13 @@ export default {
               scripts: [],
               styles: [],
             },
+            base: '/app1',
           },
           {
             name: 'app2',
             // 支持 html entry
             entry: '/path/to/app/index.html',
+            base: '/app2',
           },
         ],
         jsSandBox: true, // 是否启用 js 沙箱，默认为 false
@@ -118,7 +120,7 @@ export default {
 
 ```js
 export default {
-  base: `/${appName}`, // 应用的 routerBase，默认为 package.json 中的 name 字段
+  base: `/${appName}`, // 应用的 base，默认为 package.json 中的 name 字段
   plugins: [
     [
       '@umijs/plugin-qiankun/slave',

--- a/examples/app1/pages/index.less
+++ b/examples/app1/pages/index.less
@@ -5,6 +5,6 @@
 
 :global {
   .normalTest {
-    background: red;
+    background: green;
   }
 }

--- a/examples/master/.umirc.js
+++ b/examples/master/.umirc.js
@@ -1,5 +1,4 @@
 export default {
-  history: 'hash',
   plugins: [
     [
       '../../master',
@@ -8,7 +7,6 @@ export default {
           {
             name: 'app1',
             entry: 'http://localhost:8002',
-            history: 'hash',
             base: '/app1',
             mountElementId: 'app-root',
           },

--- a/examples/master/.umirc.js
+++ b/examples/master/.umirc.js
@@ -1,4 +1,5 @@
 export default {
+  history: 'hash',
   plugins: [
     [
       '../../master',
@@ -6,14 +7,15 @@ export default {
         apps: [
           {
             name: 'app1',
-            routerBase: '#/app1',
             entry: 'http://localhost:8002',
+            history: 'hash',
+            base: '/app1',
             mountElementId: 'app-root',
           },
           {
             name: 'app2',
-            routerBase: '#/app2',
             entry: 'http://localhost:8003',
+            base: '/app2',
             mountElementId: 'app-root',
           },
         ],

--- a/examples/master/layouts/index.js
+++ b/examples/master/layouts/index.js
@@ -10,10 +10,10 @@ export default function() {
             <Link to="/">Home</Link>
           </li>
           <li>
-            <a href="/#/app1">App1</a>
+            <Link to="/app1">app1</Link>
           </li>
           <li>
-            <a href="/#/app2">App2</a>
+            <Link to="/app2">Home</Link>
           </li>
         </ul>
       </header>

--- a/examples/master/layouts/index.js
+++ b/examples/master/layouts/index.js
@@ -13,7 +13,7 @@ export default function() {
             <Link to="/app1">app1</Link>
           </li>
           <li>
-            <Link to="/app2">Home</Link>
+            <Link to="/app2">app2</Link>
           </li>
         </ul>
       </header>

--- a/examples/master/layouts/index.js
+++ b/examples/master/layouts/index.js
@@ -10,10 +10,10 @@ export default function() {
             <Link to="/">Home</Link>
           </li>
           <li>
-            <Link to="#/app1">App1</Link>
+            <a href="/#/app1">App1</a>
           </li>
           <li>
-            <Link to="#/app2">App2</Link>
+            <a href="/#/app2">App2</a>
           </li>
         </ul>
       </header>

--- a/src/common.ts
+++ b/src/common.ts
@@ -6,6 +6,7 @@
 export const defaultMountContainerId = 'root-subapp';
 export const defaultMasterRootId = 'root-master';
 export const defaultSlaveContainerId = 'root-slave';
+export const defaultHistoryMode = 'hash';
 
 // @formatter:off
 export const noop = () => {};

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,3 +11,7 @@ export const defaultHistoryMode = 'browser';
 // @formatter:off
 export const noop = () => {};
 // @formatter:on
+
+export function toArray<T>(source: T | T[]): T[] {
+  return Array.isArray(source) ? source : [source];
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -6,7 +6,7 @@
 export const defaultMountContainerId = 'root-subapp';
 export const defaultMasterRootId = 'root-master';
 export const defaultSlaveContainerId = 'root-slave';
-export const defaultHistoryMode = 'hash';
+export const defaultHistoryMode = 'browser';
 
 // @formatter:off
 export const noop = () => {};

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -18,18 +18,15 @@ export default function(api: IApi, options: Options) {
     };
   });
 
-  const { config: { history } } = api;
+  const { config: { history = defaultHistoryMode } } = api;
   const { apps } = options;
 
-  /**
-   * 当子应用的 history mode 跟主应用一致时，为避免出现 404 手动为主应用创建一个 path 为 子应用 routerBase 的空 div 路由组件
-   * @param historyMode
-   */
-  function modifyAppRoutes(historyMode: IConfig['history']) {
+  function modifyAppRoutes(masterHistory: IConfig['history']) {
     api.modifyRoutes(routes => {
-      let newRoutes = [...routes];
-      apps.forEach(({ history = defaultHistoryMode, base }) => {
-        if (history === historyMode) {
+      const newRoutes = [...routes];
+      apps.forEach(({ history: slaveHistory = defaultHistoryMode, base }) => {
+        // 当子应用的 history mode 跟主应用一致时，为避免出现 404 手动为主应用创建一个 path 为 子应用 rule 的空 div 路由组件
+        if (slaveHistory === masterHistory) {
           newRoutes.push({ path: `${base}/*`, component: `() => React.createElement('div')` });
         }
       });

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -1,18 +1,13 @@
+import assert from 'assert';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi-types';
-import { defaultMasterRootId } from '../common';
+import IConfig from 'umi-types/config';
+import { defaultHistoryMode, defaultMasterRootId } from '../common';
+import { Options } from '../types';
 
-interface IApp {
-  scripts?: [];
-  styles?: [];
-}
-
-interface IOptions {
-  apps?: IApp[];
-}
-
-export default function(api: IApi, options: IOptions = {}) {
+export default function(api: IApi, options: Options) {
+  assert(options && options.apps && options.apps.length, 'sub apps must be config when using umi-plugin-qiankun');
   api.addRuntimePlugin(require.resolve('./runtimePlugin'));
 
   api.modifyDefaultConfig(config => {
@@ -22,6 +17,27 @@ export default function(api: IApi, options: IOptions = {}) {
       disableGlobalVariables: true,
     };
   });
+
+  const { config: { history } } = api;
+  const { apps } = options;
+
+  /**
+   * 当子应用的 history mode 跟主应用一致时，为避免出现 404 手动为主应用创建一个 path 为 子应用 routerBase 的空 div 路由组件
+   * @param historyMode
+   */
+  function modifyAppRoutes(historyMode: IConfig['history']) {
+    api.modifyRoutes(routes => {
+      let newRoutes = [...routes];
+      apps.forEach(({ history = defaultHistoryMode, base }) => {
+        if (history === historyMode) {
+          newRoutes.push({ path: `${base}/*`, component: `() => React.createElement('div')` });
+        }
+      });
+      return newRoutes;
+    });
+  }
+
+  modifyAppRoutes(history);
 
   const rootExportsFile = join(api.paths.absSrcPath, 'rootExports.js');
   api.addPageWatcher(rootExportsFile);

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { IApi } from 'umi-types';
 import IConfig from 'umi-types/config';
-import { defaultHistoryMode, defaultMasterRootId } from '../common';
+import { defaultHistoryMode, defaultMasterRootId, toArray } from '../common';
 import { Options } from '../types';
 
 export default function(api: IApi, options: Options) {
@@ -27,7 +27,11 @@ export default function(api: IApi, options: Options) {
       apps.forEach(({ history: slaveHistory = defaultHistoryMode, base }) => {
         // 当子应用的 history mode 跟主应用一致时，为避免出现 404 手动为主应用创建一个 path 为 子应用 rule 的空 div 路由组件
         if (slaveHistory === masterHistory) {
-          newRoutes.push({ path: `${base}/*`, component: `() => React.createElement('div')` });
+          const baseConfig = toArray(base);
+          baseConfig.forEach(basePath => newRoutes.push({
+            path: `${basePath}/*`,
+            component: `() => React.createElement('div')`,
+          }));
         }
       });
       return newRoutes;

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -3,24 +3,34 @@ import subAppConfig from '@tmp/subAppsConfig.json';
 import { registerMicroApps, start } from 'qiankun';
 import React from 'react';
 import ReactDOM from 'react-dom';
-import { defaultMountContainerId, noop } from '../common';
+import { IConfig } from 'umi-types';
+import { defaultHistoryMode, defaultMountContainerId, noop } from '../common';
+import { Options } from '../types';
 
 export function render(oldRender: typeof noop) {
   oldRender();
 
-  function isAppActive(location: Location, routerBase: string) {
-    // TODO 支持 browserHistory， 根据当前配置的 history 类型决定
-    return location.hash.startsWith(routerBase);
+  function isAppActive(location: Location, history: IConfig['history'], base: IConfig['base'] = '/') {
+    switch (history) {
+      case 'hash':
+        return location.hash.startsWith(`#${base}`);
+
+      case 'browser':
+        return location.pathname.startsWith(base);
+
+      default:
+        return false;
+    }
   }
 
-  const { apps, jsSandbox = false, prefetch = true } = subAppConfig;
+  const { apps, jsSandbox = false, prefetch = true } = subAppConfig as Options;
   registerMicroApps(
-    apps.map(({ name, entry, routerBase, mountElementId = defaultMountContainerId, ...props }) => {
+    apps.map(({ name, entry, base, history = defaultHistoryMode, mountElementId = defaultMountContainerId, ...props }) => {
 
       return {
         name,
         entry,
-        activeRule: location => isAppActive(location, routerBase),
+        activeRule: location => isAppActive(location, history, base),
         render: ({ appContent, loading }) => {
           if (process.env.NODE_ENV === 'development') {
             console.info(`app ${name} loading ${loading}`);

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -4,19 +4,21 @@ import { registerMicroApps, start } from 'qiankun';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { IConfig } from 'umi-types';
-import { defaultHistoryMode, defaultMountContainerId, noop } from '../common';
+import { defaultHistoryMode, defaultMountContainerId, noop, toArray } from '../common';
 import { App, Options } from '../types';
 
 export function render(oldRender: typeof noop) {
   oldRender();
 
-  function isAppActive(location: Location, history: IConfig['history'], base: App['base'] = '/') {
+  function isAppActive(location: Location, history: IConfig['history'], base: App['base']) {
+    const baseConfig = toArray(base);
+
     switch (history) {
       case 'hash':
-        return location.hash.startsWith(`#${base}`);
+        return baseConfig.some(pathPrefix => location.hash.startsWith(`#${pathPrefix}`));
 
       case 'browser':
-        return location.pathname.startsWith(base);
+        return baseConfig.some(pathPrefix => location.pathname.startsWith(pathPrefix));
 
       default:
         return false;

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -5,12 +5,12 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import { IConfig } from 'umi-types';
 import { defaultHistoryMode, defaultMountContainerId, noop } from '../common';
-import { Options } from '../types';
+import { App, Options } from '../types';
 
 export function render(oldRender: typeof noop) {
   oldRender();
 
-  function isAppActive(location: Location, history: IConfig['history'], base: IConfig['base'] = '/') {
+  function isAppActive(location: Location, history: IConfig['history'], base: App['base'] = '/') {
     switch (history) {
       case 'hash':
         return location.hash.startsWith(`#${base}`);

--- a/src/slave/index.ts
+++ b/src/slave/index.ts
@@ -17,8 +17,6 @@ export default function(api: IApi, options: IOptions = {}) {
     return {
       ...memo,
       disableGlobalVariables: true,
-      // TODO: 支持 browser history
-      history: 'hash',
       base: `/${pkgName}`,
       mountElementId,
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,7 @@ import IConfig from 'umi-types/config';
 export type App = {
   name: string;
   entry: string | { scripts: string[], styles: string[] };
-  base: Required<IConfig['base']>;
+  base: string | string[];
 } & Pick<IConfig, 'history' | 'mountElementId'>;
 
 export type Options = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,17 @@
+/**
+ * @author Kuitos
+ * @since 2019-06-20
+ */
+
+import IConfig from 'umi-types/config';
+
+export type App = {
+  name: string;
+  entry: string | { scripts: string[], styles: string[] };
+} & Pick<IConfig, 'base' | 'history' | 'mountElementId'>;
+
+export type Options = {
+  apps: App[];
+  jsSandbox: boolean;
+  prefetch: boolean;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,8 @@ import IConfig from 'umi-types/config';
 export type App = {
   name: string;
   entry: string | { scripts: string[], styles: string[] };
-} & Pick<IConfig, 'base' | 'history' | 'mountElementId'>;
+  base: Required<IConfig['base']>;
+} & Pick<IConfig, 'history' | 'mountElementId'>;
 
 export type Options = {
   apps: App[];

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -3,20 +3,6 @@
  * @since 2019-06-20
  */
 
-declare module '@tmp/subAppsConfig.json' {
-  type App = {
-    name: string;
-    entry: string | { scripts: string[], styles: string[] };
-    routerBase: string;
-    mountElementId: string;
-  };
-
-  const configuration: {
-    apps: App[];
-    jsSandbox: boolean;
-    prefetch: boolean;
-  };
-  export default configuration;
-}
+declare module '@tmp/subAppsConfig.json';
 
 declare module '@tmp/qiankunRootExports.js';


### PR DESCRIPTION
1. 子应用 history mode 跟主应用一致时，自动生成相应的路由配置，避免出现主应用 404 的问题 close https://github.com/umijs/umi/issues/2726
2. routerBase 配置改为 -> base，直接复用 umi 的配置，降低用户的理解成本
3. 支持 browserHistory
