### PR TITLE
demo:主应用和子应用联调

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ $ yarn start
 - ✔︎ 支持主子应用 browser、hash 等多种 history 模式
 - ✔︎ 父子应用通讯
 - ✔︎ 子应用运行时配置自定义 `bootstrap()`、`mount()` 和 `unmount()`
+- ✔︎ 主应用、子应用联调，.env 配置 SOCKET_SERVER，子应用 websocket 跨域访问
 
 ## Usage
 

--- a/examples/app1/.env
+++ b/examples/app1/.env
@@ -1,4 +1,4 @@
 PORT=8001
 BROWSER=none
-# 变更webpack-dev-server websocket默认监听地址
+# 变更 webpack-dev-server websocket 默认监听地址
 SOCKET_SERVER=http://localhost:8001/

--- a/examples/app1/.env
+++ b/examples/app1/.env
@@ -1,3 +1,4 @@
 PORT=8001
 BROWSER=none
-
+# 变更webpack-dev-server websocket默认监听地址
+SOCKET_SERVER=http://localhost:8001/

--- a/examples/app2/.env
+++ b/examples/app2/.env
@@ -1,3 +1,3 @@
 PORT=8002
 BROWSER=none
-
+SOCKET_SERVER=http://localhost:8002/

--- a/src/slave/index.ts
+++ b/src/slave/index.ts
@@ -26,12 +26,14 @@ export default function (api: IApi) {
     assert(api.pkg.name, `You should have name in package.json`);
     memo.output!.library = api.pkg.name;
     memo.output!.jsonpFunction = `webpackJsonp_${api.pkg.name}`;
-    // 禁用devtool，启用SourceMapDevToolPlugin
-    memo.devtool = false
+    // 禁用 devtool，启用 SourceMapDevToolPlugin
+    if (process.env.NODE_ENV === 'development') {
+      memo.devtool = false;
+    }
     return memo;
   });
 
-  // source-map跨域设置
+  // source-map 跨域设置
   api.chainWebpackConfig((memo) => {
     if (process.env.NODE_ENV === 'development') {
       const app = api.config.mountElementId


### PR DESCRIPTION
支出在主应用上自动跟踪子应用代码变更，刷新浏览器

.env 配置 SOCKET_SERVER
具体参见[af-webpack/src/webpackHotDevClient](https://github.com/umijs/umi/blob/137ba9a710afc4af509b1341f88ff9d46f65ec67/packages/af-webpack/src/webpackHotDevClient.js#L60)

主应用加载子应用支持sourcemap

todo
子应用webpack热更新，目前浏览器会刷新，期待结果，无刷新