### PR TITLE
:sparkles: 支持异步启动 qiankun

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,9 @@ export const qiankun = fetch('/config').then(() => ({
 | apps      | 子应用配置                                                                                                                                                                                                                                                                                                    | App[]   | 是       |        |
 | jsSandbox | 是否启用 js 沙箱                                                                                                                                                                                                                                                                                              | boolean | 否       | false  |
 | prefetch  | 是否启用 prefetch 特性                                                                                                                                                                                                                                                                                        | boolean | 否       | true   |
-| defer     | 是否异步渲染，比如子应用的 mountElementId 依赖主应用生成的节点，而主应用生成该节点的过程是异步的。<br />当该配置开启的时候，可以使用 `import { qiankunStart } from 'umi'` api 通知 qiankun 启动。参考 [example](https://github.com/umijs/umi-plugin-qiankun/blob/master/examples/master/layouts/index.js#L34) | boolean | 否       | False  |
+| defer     | 是否异步渲染，比如子应用的 mountElementId 依赖主应用生成的节点，而主应用生成该节点的过程是异步的。<br />当该配置开启的时候，可以使用 `import { qiankunStart } from 'umi'` api 通知 qiankun 启动。参考 [example](https://github.com/umijs/umi-plugin-qiankun/blob/master/examples/master/layouts/index.js#L34) | boolean | 否       | false  |
+
+[qiankun start](https://github.com/umijs/qiankun#start) 方法其他可接收的参数在这里也都可以配置
 
 #### App
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ yarn start
 
 ### 主应用
 
-#### 构建期配置
+#### 构建期
 
 ```js
 export default {
@@ -69,7 +69,7 @@ export default {
             base: '/app2',
           },
         ],
-        jsSandBox: true, // 是否启用 js 沙箱，默认为 false
+        jsSandbox: true, // 是否启用 js 沙箱，默认为 false
         prefetch: true, // 是否启用 prefetch 特性，默认为 true
       },
     ],
@@ -77,7 +77,7 @@ export default {
 };
 ```
 
-#### 运行时配置
+#### 运行时
 
 ```js
 export default {
@@ -109,12 +109,21 @@ export const qiankun = fetch('/config').then(() => ({
       base: '/app2',
     },
   ],
-  jsSandBox: true, // 是否启用 js 沙箱，默认为 false
+  jsSandbox: true, // 是否启用 js 沙箱，默认为 false
   prefetch: true, // 是否启用 prefetch 特性，默认为 true
 }));
 ```
 
-#### app 配置
+### 配置列表
+
+| 配置      | 说明                                                                                                                                                                                                                                                                                                          | 类型    | 是否必填 | 默认值 |
+| --------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- | ------ |
+| apps      | 子应用配置                                                                                                                                                                                                                                                                                                    | App[]   | 是       |        |
+| jsSandbox | 是否启用 js 沙箱                                                                                                                                                                                                                                                                                              | boolean | 否       | false  |
+| prefetch  | 是否启用 prefetch 特性                                                                                                                                                                                                                                                                                        | boolean | 否       | true   |
+| defer     | 是否异步渲染，比如子应用的 mountElementId 依赖主应用生成的节点，而主应用生成该节点的过程是异步的。<br />当该配置开启的时候，可以使用 `import { qiankunStart } from 'umi'` api 通知 qiankun 启动。参考 [example](https://github.com/umijs/umi-plugin-qiankun/blob/master/examples/master/layouts/index.js#L34) | boolean | 否       | False  |
+
+#### App
 
 | 配置           | 说明                                                                                                                          | 类型                                       | 是否必填 | 默认值      |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | -------- | ----------- |

--- a/examples/master/.umirc.js
+++ b/examples/master/.umirc.js
@@ -13,6 +13,7 @@ export default {
     [
       '../../master',
       {
+        defer: true,
         jsSandbox: true,
         prefetch: true,
       },

--- a/examples/master/app.js
+++ b/examples/master/app.js
@@ -1,35 +1,6 @@
 // 标识位，方便子应用单独调试
+import request from './services/request';
+
 window.isMain = true;
 
-// 异步demo
-export const qiankun = new Promise(resolve => {
-  setTimeout(() => {
-    window.g_app._store
-      .dispatch({
-        type: 'base/getApps',
-      })
-      .then(apps => {
-        resolve({
-          apps,
-        });
-      });
-  }, 0);
-});
-
-// 同步demo
-// export const qiankun = {
-//   apps: [
-//     {
-//       name: 'app1',
-//       entry: 'http://localhost:8001/app1',
-//       base: '/app1',
-//       mountElementId: 'root-slave',
-//     },
-//     {
-//       name: 'app2',
-//       entry: 'http://localhost:8002/app2',
-//       base: '/app2',
-//       mountElementId: 'root-slave',
-//     },
-//   ],
-// }
+export const qiankun = request('/apps').then(apps => ({ apps }));

--- a/examples/master/layouts/index.js
+++ b/examples/master/layouts/index.js
@@ -1,7 +1,7 @@
 import { Breadcrumb, Layout, Menu } from 'antd';
 import { connect } from 'dva';
 import React from 'react';
-import { Link } from 'umi';
+import { Link, qiankunStart } from 'umi';
 import style from './style.less';
 
 const { Header, Content, Footer } = Layout;
@@ -28,6 +28,10 @@ export default class extends React.PureComponent {
     dispatch({
       type: 'base/getApps',
     });
+  }
+
+  componentDidMount() {
+    qiankunStart();
   }
 
   render() {
@@ -59,8 +63,9 @@ export default class extends React.PureComponent {
         </Header>
         <Content className={style.content}>
           {renderBreadCrumb(location.pathname)}
-          {// 加载master pages，此处判断较为简单，实际需排除所有子应用bas打头的路径
-          selectKey === '/' ? children : <div id="root-slave"></div>}
+          {// 加载master pages，此处判断较为简单，实际需排除所有子应用base打头的路径
+          selectKey === '/' ? children : null}
+          <div id="root-slave" />
         </Content>
         <Footer className={style.footer}>Ant Design ©2019 Created by Ant UED</Footer>
       </Layout>

--- a/examples/master/layouts/index.js
+++ b/examples/master/layouts/index.js
@@ -1,7 +1,7 @@
 import { Breadcrumb, Layout, Menu } from 'antd';
 import { connect } from 'dva';
 import React from 'react';
-import { Link, qiankunStart } from 'umi';
+import { Link } from 'umi';
 import style from './style.less';
 
 const { Header, Content, Footer } = Layout;
@@ -28,10 +28,6 @@ export default class extends React.PureComponent {
     dispatch({
       type: 'base/getApps',
     });
-  }
-
-  componentDidMount() {
-    qiankunStart();
   }
 
   render() {
@@ -65,7 +61,7 @@ export default class extends React.PureComponent {
           {renderBreadCrumb(location.pathname)}
           {// 加载master pages，此处判断较为简单，实际需排除所有子应用base打头的路径
           selectKey === '/' ? children : null}
-          <div id="root-slave" />
+          {apps.length ? <div id="root-slave" /> : null}
         </Content>
         <Footer className={style.footer}>Ant Design ©2019 Created by Ant UED</Footer>
       </Layout>

--- a/examples/master/models/base.js
+++ b/examples/master/models/base.js
@@ -1,4 +1,9 @@
 import { query } from '@/services/app';
+import { qiankunStart } from 'umi';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 export default {
   namespace: 'base',
@@ -14,6 +19,9 @@ export default {
        子应用配置信息获取分同步、异步两种方式
        同步有两种配置方式，1、app.js导出qiankun对象，2、配置写在umi配置文件中，可通过import @tmp/subAppsConfig获取
       */
+      console.log('waiting for qiankun start');
+      yield sleep(1000);
+
       const apps = yield query();
       console.log(apps);
       yield put({
@@ -22,7 +30,9 @@ export default {
           apps,
         },
       });
-      return apps;
+
+      // 模拟手动控制 qiankun 启动时机的场景, 需要 defer 配置为 true
+      setTimeout(qiankunStart, 1000);
     },
   },
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "node": ">=8.0.0"
   },
   "scripts": {
-    "start": "npm run start:master & npm run start:app1 & npm run start:app2",
+    "start": "concurrently \"npm run start:master\" \"npm run start:app1\" \"npm run start:app2\"",
     "coveralls": "cat ./coverage/lcov.info | coveralls",
     "prepublishOnly": "npm run build",
     "build": "father-build",
@@ -34,6 +34,7 @@
   },
   "devDependencies": {
     "@types/react-dom": "^16.8.4",
+    "concurrently": "^4.1.2",
     "coveralls": "3",
     "father-build": "^1.2.0",
     "husky": "1",

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -5,6 +5,7 @@ import IConfig from 'umi-types/config';
 import { defaultHistoryMode, defaultMasterRootId, toArray } from '../common';
 import { Options } from '../types';
 
+// @ts-ignore
 export default function(api: IApi, options: Options = {}) {
   api.addRuntimePlugin(require.resolve('./runtimePlugin'));
   api.addRuntimePluginKey('qiankun');
@@ -64,4 +65,21 @@ window.g_rootExports = ${existsSync(rootExportsFile) ? `require('@/rootExports')
     api.writeTmpFile('qiankunRootExports.js', rootExports);
     api.writeTmpFile('subAppsConfig.json', JSON.stringify(options));
   });
+
+  api.writeTmpFile('qiankunDefer.js', `
+      class Deferred { 
+        constructor() {
+          this.promise = new Promise(resolve => this.resolve = resolve);
+        }
+      }
+      export const deferred = new Deferred();
+      export const qiankunStart = deferred.resolve;
+    `.trim());
+
+  api.addUmiExports([
+    {
+      specifiers: ['qiankunStart'],
+      source: '@tmp/qiankunDefer',
+    },
+  ]);
 }

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -33,7 +33,7 @@ export async function render(oldRender: typeof noop) {
   }
 
   const runtimeConfig = await getMasterRuntime();
-  const { apps, jsSandbox = false, prefetch = true, defer = false, lifeCycles } = { ...subAppConfig as Options, ...runtimeConfig as Options } as Options;
+  const { apps, jsSandbox = false, prefetch = true, defer = false, lifeCycles, ...props } = { ...subAppConfig as Options, ...runtimeConfig as Options } as Options;
   assert(apps && apps.length, 'sub apps must be config when using umi-plugin-qiankun');
 
   registerMicroApps(
@@ -70,5 +70,5 @@ export async function render(oldRender: typeof noop) {
     await deferred.promise;
   }
 
-  start({ jsSandbox, prefetch });
+  start({ jsSandbox, prefetch, ...props });
 }

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -1,3 +1,4 @@
+import { deferred } from '@tmp/qiankunDefer.js';
 import '@tmp/qiankunRootExports.js';
 import subAppConfig from '@tmp/subAppsConfig.json';
 import assert from 'assert';
@@ -32,7 +33,7 @@ export async function render(oldRender: typeof noop) {
   }
 
   const runtimeConfig = await getMasterRuntime();
-  const { apps, jsSandbox = false, prefetch = true, lifeCycles } = { ...subAppConfig as Options, ...runtimeConfig as Options };
+  const { apps, jsSandbox = false, prefetch = true, defer = false, lifeCycles } = { ...subAppConfig as Options, ...runtimeConfig as Options } as Options;
   assert(apps && apps.length, 'sub apps must be config when using umi-plugin-qiankun');
 
   registerMicroApps(
@@ -64,6 +65,10 @@ export async function render(oldRender: typeof noop) {
     }),
     lifeCycles,
   );
+
+  if (defer) {
+    await deferred.promise;
+  }
 
   start({ jsSandbox, prefetch });
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,8 +3,8 @@
  * @since 2019-06-20
  */
 
-import IConfig from 'umi-types/config';
 import { LifeCycles } from 'qiankun';
+import IConfig from 'umi-types/config';
 
 export type App = {
   name: string;
@@ -16,5 +16,6 @@ export type Options = {
   apps: App[];
   jsSandbox: boolean;
   prefetch: boolean;
+  defer?: boolean;
   lifeCycles?: LifeCycles<object>;
 };

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -6,3 +6,8 @@
 declare module '@tmp/subAppsConfig.json';
 
 declare module '@tmp/qiankunRootExports.js';
+
+declare module '@tmp/qiankunDefer.js' {
+  const deferred: any;
+  export { deferred };
+}


### PR DESCRIPTION
有一些场景子应用的需要挂载的 mountElementId 节点是有主应用异步生成的，如果在节点生成之前子应用就已经启动的话，会造成 Target dom is not container 异常

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi-plugin-qiankun/25)
<!-- Reviewable:end -->
