### PR TITLE
:sparkles: 1. 子应用 history 默认跟主应用保持一致 2. 将对子应用配置的 history 跟 base 透传到运行时

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 
 Umi plugin for [qiankun](https://github.com/umijs/qiankun).
 
-[![NPM version](https://img.shields.io/npm/v/@umijs/plugin-qiankun.svg?style=flat)](https://npmjs.org/package/@umijs/plugin-qiankun)
-[![Build Status](https://img.shields.io/travis/umijs/umi-plugin-qiankun.svg?style=flat)](https://travis-ci.org/umijs/umi-plugin-qiankun)
-[![NPM downloads](http://img.shields.io/npm/dm/@umijs/plugin-qiankun.svg?style=flat)](https://npmjs.org/package/@umijs/plugin-qiankun)
+[![NPM version](https://img.shields.io/npm/v/@umijs/plugin-qiankun.svg?style=flat)](https://npmjs.org/package/@umijs/plugin-qiankun) [![Build Status](https://img.shields.io/travis/umijs/umi-plugin-qiankun.svg?style=flat)](https://travis-ci.org/umijs/umi-plugin-qiankun) [![NPM downloads](http://img.shields.io/npm/dm/@umijs/plugin-qiankun.svg?style=flat)](https://npmjs.org/package/@umijs/plugin-qiankun)
 
 ## Installation
 
@@ -57,7 +55,7 @@ export default {
             name: 'app1', // 唯一 id
             entry: '//localhost:7001', // html entry
             base: '/app1', // app1 的路由前缀，通过这个前缀判断是否要启动该应用，通常跟子应用的 base 保持一致
-            history: 'browser', // 子应用的 history 配置，默认为 'browser'
+            history: 'browser', // 子应用的 history 配置，默认为当前主应用 history 配置
           },
           {
             name: 'app2',
@@ -97,7 +95,7 @@ export const qiankun = fetch('/config').then(() => ({
       name: 'app1', // 唯一 id
       entry: '//localhost:7001', // html entry
       base: '/app1', // app1 的路由前缀，通过这个前缀判断是否要启动该应用，通常跟子应用的 base 保持一致
-      history: 'browser', // 子应用的 history 配置，默认为 'browser'
+      history: 'browser', // 子应用的 history 配置，默认为当前主应用 history 配置
     },
     {
       name: 'app2',
@@ -123,25 +121,25 @@ export const qiankun = fetch('/config').then(() => ({
 
 ### 配置列表
 
-| 配置      | 说明                                                                                                                                                                                                                                                                                                        | 类型    | 是否必填 | 默认值 |
-| --------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------- | ------ |
-| apps      | 子应用配置                                                                                                                                                                                                                                                                                                  | App[]   | 是       |        |
-| jsSandbox | 是否启用 js 沙箱                                                                                                                                                                                                                                                                                            | boolean | 否       | false  |
-| prefetch  | 是否启用 prefetch 特性                                                                                                                                                                                                                                                                                      | boolean | 否       | true   |
-| defer     | 是否异步渲染，比如子应用的 mountElementId 依赖主应用生成的节点，而主应用生成该节点的过程是异步的。<br />当该配置开启的时候，可以使用 `import { qiankunStart } from 'umi'` api 通知 qiankun 启动。参考 [example](https://github.com/umijs/umi-plugin-qiankun/blob/master/examples/master/models/base.js#L35) | boolean | 否       | false  |
+| 配置 | 说明 | 类型 | 是否必填 | 默认值 |
+| --- | --- | --- | --- | --- |
+| apps | 子应用配置 | App[] | 是 |  |
+| jsSandbox | 是否启用 js 沙箱 | boolean | 否 | false |
+| prefetch | 是否启用 prefetch 特性 | boolean | 否 | true |
+| defer | 是否异步渲染，比如子应用的 mountElementId 依赖主应用生成的节点，而主应用生成该节点的过程是异步的。<br />当该配置开启的时候，可以使用 `import { qiankunStart } from 'umi'` api 通知 qiankun 启动。参考 [example](https://github.com/umijs/umi-plugin-qiankun/blob/master/examples/master/models/base.js#L35) | boolean | 否 | false |
 
 [qiankun start](https://github.com/umijs/qiankun#start) 方法其他可接收的参数在这里也都可以配置
 
 #### App
 
-| 配置           | 说明                                                                                                                          | 类型                                       | 是否必填 | 默认值      |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------ | -------- | ----------- |
-| name           | 子应用唯一 id                                                                                                                 | string                                     | 是       |             |
-| entry          | 子应用 html 地址                                                                                                              | string \| { script: string[], styles: [] } | 是       |             |
-| base           | 子应用路由前缀，通常跟子应用的 [base 配置](https://umijs.org/config/#base) 一致，框架会以这个配置作为前缀判断是否激活当前应用 | string \| string[]                         | 是       |             |
-| history        | [umi history mode](https://umijs.org/config/#history)                                                                         | string                                     | 否       | browser     |
-| mountElementId | 子应用挂载到主应用的哪个 id 节点上（注意不要跟子应用的 mountElementId 一致）                                                  | string                                     | 否       | root-subapp |
-| props          | 主应用传递给子应用的数据                                                                                                      | object                                     | 否       | {}          |
+| 配置 | 说明 | 类型 | 是否必填 | 默认值 |
+| --- | --- | --- | --- | --- |
+| name | 子应用唯一 id | string | 是 |  |
+| entry | 子应用 html 地址 | string \| { script: string[], styles: [] } | 是 |  |
+| base | 子应用路由前缀，通常跟子应用的 [base 配置](https://umijs.org/config/#base) 一致，框架会以这个配置作为前缀判断是否激活当前应用 | string \| string[] | 是 |  |
+| history | [umi history mode](https://umijs.org/config/#history) | string | 否 | 主应用 history 配置 |
+| mountElementId | 子应用挂载到主应用的哪个 id 节点上（注意不要跟子应用的 mountElementId 一致） | string | 否 | root-subapp |
+| props | 主应用传递给子应用的数据 | object | 否 | {} |
 
 ### 子应用
 

--- a/examples/app1/.umirc.js
+++ b/examples/app1/.umirc.js
@@ -1,8 +1,5 @@
-import { name } from './package';
-
 export default {
   base: '/app1',
-  history: 'browser',
   publicPath: '/app1/',
   outputPath: './dist/app1',
   mountElementId: 'app1',

--- a/examples/app2/.umirc.js
+++ b/examples/app2/.umirc.js
@@ -2,7 +2,6 @@ import { name } from './package';
 
 export default {
   base: name,
-  history: 'browser',
   publicPath: '/app2/',
   outputPath: './dist/app2',
   mountElementId: 'app2',

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -64,7 +64,13 @@ export default function(api: IApi, options: Options) {
 window.g_rootExports = ${existsSync(rootExportsFile) ? `require('@/rootExports')` : `{}`};
     `.trim();
     api.writeTmpFile('qiankunRootExports.js', rootExports);
-    api.writeTmpFile('subAppsConfig.json', JSON.stringify(options));
+    api.writeTmpFile(
+      'subAppsConfig.json',
+      JSON.stringify({
+        masterHistory: api.config.history || defaultHistoryMode,
+        ...options,
+      }),
+    );
   });
 
   api.writeTmpFile(

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -1,6 +1,5 @@
 /* eslint-disable import/no-unresolved, import/extensions */
 
-// eslint-disable-next-line import/extensions
 import { deferred } from '@tmp/qiankunDefer.js';
 import '@tmp/qiankunRootExports.js';
 import subAppConfig from '@tmp/subAppsConfig.json';
@@ -9,7 +8,7 @@ import { registerMicroApps, start } from 'qiankun';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { IConfig } from 'umi-types';
-import { defaultHistoryMode, defaultMountContainerId, noop, toArray } from '../common';
+import { defaultMountContainerId, noop, toArray } from '../common';
 import { App, Options } from '../types';
 
 async function getMasterRuntime() {
@@ -37,38 +36,40 @@ export async function render(oldRender: typeof noop) {
   }
 
   const runtimeConfig = await getMasterRuntime();
-  const { apps, jsSandbox = false, prefetch = true, defer = false, lifeCycles, ...otherConfigs } = {
+  const { apps, jsSandbox = false, prefetch = true, defer = false, lifeCycles, masterHistory, ...otherConfigs } = {
     ...(subAppConfig as Options),
     ...(runtimeConfig as Options),
   };
   assert(apps && apps.length, 'sub apps must be config when using umi-plugin-qiankun');
 
   registerMicroApps(
-    apps.map(
-      ({ name, entry, base, history = defaultHistoryMode, mountElementId = defaultMountContainerId, props }) => ({
-        name,
-        entry,
-        activeRule: location => isAppActive(location, history, base),
-        render: ({ appContent, loading }) => {
-          if (process.env.NODE_ENV === 'development') {
-            console.info(`app ${name} loading ${loading}`);
-          }
+    apps.map(({ name, entry, base, history = masterHistory, mountElementId = defaultMountContainerId, props }) => ({
+      name,
+      entry,
+      activeRule: location => isAppActive(location, history, base),
+      render: ({ appContent, loading }) => {
+        if (process.env.NODE_ENV === 'development') {
+          console.info(`app ${name} loading ${loading}`);
+        }
 
-          if (mountElementId) {
-            const container = document.getElementById(mountElementId);
-            if (container) {
-              const subApp = React.createElement('div', {
-                dangerouslySetInnerHTML: {
-                  __html: appContent,
-                },
-              });
-              ReactDOM.render(subApp, container);
-            }
+        if (mountElementId) {
+          const container = document.getElementById(mountElementId);
+          if (container) {
+            const subApp = React.createElement('div', {
+              dangerouslySetInnerHTML: {
+                __html: appContent,
+              },
+            });
+            ReactDOM.render(subApp, container);
           }
-        },
-        props,
-      }),
-    ),
+        }
+      },
+      props: {
+        base,
+        history,
+        ...props,
+      },
+    })),
     lifeCycles,
   );
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,4 +19,5 @@ export type Options = {
   prefetch: boolean;
   defer?: boolean;
   lifeCycles?: LifeCycles<object>;
+  masterHistory: IConfig['history'];
 };


### PR DESCRIPTION
1. 子应用 history 默认跟主应用保持一致
2. 将对子应用配置的 history 跟 base 透传到运行时

close https://github.com/umijs/umi/issues/3473

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi-plugin-qiankun/33)
<!-- Reviewable:end -->
