### PR TITLE
修复全局配置引起的兼容性问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ export default {
 };
 ```
 
+如果子应用配置项为空，即 slave: {}，则可以省略配置：
+
+```js
+export default {
+  base: `/${appName}`, // 子应用的 base，默认为 package.json 中的 name 字段
+  plugins: ['@umijs/plugin-qiankun'],
+};
+```
+
 ## 父子应用通讯
 
 1. 约定父应用中在 `src/rootExports.js` 里 export 内容

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ export default function(api: IApi, options: GlobalOptions) {
     assert(!(masterOpts && slaveOpts), '请勿同时配置 master 和 slave 配置项');
     if (masterOpts) {
       api.changePluginOption('qiankun-master', { ...masterOpts, registerRuntimeKeyInIndex: true });
-    } else if (slaveOpts) {
+    } else {
       api.changePluginOption('qiankun-slave', { ...slaveOpts, registerRuntimeKeyInIndex: true });
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,8 @@
-import assert from 'assert';
-// eslint-disable-next-line import/no-unresolved
 import { IApi } from 'umi-types';
+import assert from 'assert';
+import { GlobalOptions } from './types';
 import master from './master';
 import slave from './slave';
-import { GlobalOptions } from './types';
 
 export default function(api: IApi, options: GlobalOptions) {
   api.addRuntimePluginKey('qiankun');
@@ -13,9 +12,9 @@ export default function(api: IApi, options: GlobalOptions) {
     const { master: masterOpts, slave: slaveOpts } = newOpts || {};
     assert(!(masterOpts && slaveOpts), '请勿同时配置 master 和 slave 配置项');
     if (masterOpts) {
-      api.changePluginOption('qiankun-master', { opts: masterOpts, needRegisterRuntimeKey: false });
+      api.changePluginOption('qiankun-master', { ...masterOpts, registerRuntimeKeyInIndex: true });
     } else if (slaveOpts) {
-      api.changePluginOption('qiankun-slave', { opts: slaveOpts, needRegisterRuntimeKey: false });
+      api.changePluginOption('qiankun-slave', { ...slaveOpts, registerRuntimeKeyInIndex: true });
     }
   });
 
@@ -27,13 +26,13 @@ export default function(api: IApi, options: GlobalOptions) {
     api.registerPlugin({
       id: 'qiankun-master',
       apply: master,
-      opts: { opts: masterOpts, needRegisterRuntimeKey: false },
+      opts: { ...masterOpts, registerRuntimeKeyInIndex: true },
     });
-  } else if (slaveOpts) {
+  } else {
     api.registerPlugin({
       id: 'qiankun-slave',
       apply: slave,
-      opts: { opts: slaveOpts, needRegisterRuntimeKey: false },
+      opts: { ...slaveOpts, registerRuntimeKeyInIndex: true },
     });
   }
 }

--- a/src/master/index.ts
+++ b/src/master/index.ts
@@ -4,12 +4,12 @@ import { join } from 'path';
 // eslint-disable-next-line import/no-unresolved
 import { IApi, IConfig } from 'umi-types';
 import { defaultHistoryMode, defaultMasterRootId, toArray } from '../common';
-import { MOptions } from '../types';
+import { Options } from '../types';
 
-export default function(api: IApi, opts: MOptions) {
-  const { opts: options, needRegisterRuntimeKey = true } = opts;
+export default function(api: IApi, options: Options) {
+  const { registerRuntimeKeyInIndex = false } = options;
   api.addRuntimePlugin(require.resolve('./runtimePlugin'));
-  if (needRegisterRuntimeKey) {
+  if (!registerRuntimeKeyInIndex) {
     api.addRuntimePluginKey('qiankun');
   }
 

--- a/src/master/runtimePlugin.ts
+++ b/src/master/runtimePlugin.ts
@@ -8,7 +8,7 @@ import { registerMicroApps, start } from 'qiankun';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { IConfig } from 'umi-types';
-import { defaultMountContainerId, noop, toArray } from '../common';
+import { defaultMountContainerId, noop, testPathWithPrefix, toArray } from '../common';
 import { App, Options } from '../types';
 
 async function getMasterRuntime() {
@@ -24,16 +24,13 @@ export async function render(oldRender: typeof noop) {
 
   function isAppActive(location: Location, history: IConfig['history'], base: App['base']) {
     const baseConfig = toArray(base);
-    // 可以匹配 /${pathPrefix} 或 /${pathPrefix}/ 或 /${pathPrefix}?xx=xx 或 /${pathPrefix}/?xx=xx
-    // 但不能匹配 /${pathPrefix}ABC 之类的场景
-    const genMatchRegex = (pathPrefix: string) => new RegExp(`^${pathPrefix}\\/?(\\?.*)*$`, 'g');
 
     switch (history) {
       case 'hash':
-        return baseConfig.some(pathPrefix => genMatchRegex(`#${pathPrefix}`).test(location.hash));
+        return baseConfig.some(pathPrefix => testPathWithPrefix(`#${pathPrefix}`, location.hash));
 
       case 'browser':
-        return baseConfig.some(pathPrefix => genMatchRegex(pathPrefix).test(location.pathname));
+        return baseConfig.some(pathPrefix => testPathWithPrefix(pathPrefix, location.pathname));
 
       default:
         return false;

--- a/src/slave/index.ts
+++ b/src/slave/index.ts
@@ -5,12 +5,12 @@ import { join } from 'path';
 import { IApi } from 'umi-types';
 import webpack from 'webpack';
 import { defaultSlaveRootId } from '../common';
-import { MOptions } from '../types';
+import { Options } from '../types';
 
-export default function(api: IApi, opts: MOptions) {
-  const { needRegisterRuntimeKey = true } = opts;
+export default function(api: IApi, options: Options) {
+  const { registerRuntimeKeyInIndex = false } = options;
   api.addRuntimePlugin(require.resolve('./runtimePlugin'));
-  if (needRegisterRuntimeKey) {
+  if (!registerRuntimeKeyInIndex) {
     api.addRuntimePluginKey('qiankun');
   }
 
@@ -62,7 +62,6 @@ export default function(api: IApi, opts: MOptions) {
     });
   }
 
-  api.addRuntimePlugin(require.resolve('./runtimePlugin'));
   api.writeTmpFile(
     'qiankunContext.js',
     `

--- a/src/slave/lifecycles.ts
+++ b/src/slave/lifecycles.ts
@@ -22,7 +22,8 @@ function getSlaveRuntime() {
   // eslint-disable-next-line import/no-extraneous-dependencies, global-require
   const plugins = require('umi/_runtimePlugin');
   const config = plugins.mergeConfig('qiankun');
-  return config.slave ? config.slave : config;
+  const { slave } = config || {};
+  return slave || config;
 }
 
 export function genBootstrap(promises: Promise<any>, oldRender: typeof noop) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,11 +21,7 @@ export type Options = {
   defer?: boolean;
   lifeCycles?: LifeCycles<object>;
   masterHistory: IConfig['history'];
-};
-
-export type MOptions = {
-  opts: Options;
-  needRegisterRuntimeKey: boolean;
+  registerRuntimeKeyInIndex?: boolean; // 仅做插件本身透传用，开发者无需关心
 };
 
 export type GlobalOptions = {


### PR DESCRIPTION
1. 修改兼容了 ['@umijs/plugin-qiankun/master'] 包的单独引用逻辑（之前代码有问题）。
2. 考虑到兼容以前的写法和用户的习惯，只配 qiankun: {} 的情况，认为是 slave 子应用。这点主要是考虑， slave: {} 里面一般也没什么写的，所以用户为了区分，还是得写这个空配置的话，比较麻烦。所以目前做了兼容。