### PR TITLE
将子项目中加载资源的地址由写死的 `localhost` 改为本机 ip 地址

### DIFF
--- a/examples/app1/.env
+++ b/examples/app1/.env
@@ -1,2 +1,3 @@
 PORT=8001
 BROWSER=none
+USE_REMOTE_IP=true

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/jest": "^24.0.19",
     "@types/react-dom": "^16.8.4",
     "@umijs/fabric": "^1.1.10",
+    "address": "^1.1.2",
     "check-prettier": "^1.0.3",
     "concurrently": "^4.1.2",
     "coveralls": "3",

--- a/src/slave/index.ts
+++ b/src/slave/index.ts
@@ -1,11 +1,14 @@
 /*  eslint-disable no-param-reassign */
 import assert from 'assert';
 import { join } from 'path';
+import address from 'address';
 // eslint-disable-next-line import/no-unresolved
 import { IApi } from 'umi-types';
 import webpack from 'webpack';
 import { defaultSlaveRootId } from '../common';
 import { Options } from '../types';
+
+const localIpAddress = process.env.USE_REMOTE_IP ? address.ip() : 'localhost';
 
 export default function(api: IApi, options: Options) {
   const { registerRuntimeKeyInIndex = false } = options || {};
@@ -40,7 +43,7 @@ export default function(api: IApi, options: Options) {
     memo.output!.jsonpFunction = `webpackJsonp_${api.pkg.name}`;
     // 配置 publicPath，支持 hot update
     if (process.env.NODE_ENV === 'development' && port) {
-      memo.output!.publicPath = `${protocol}://localhost:${port}/`;
+      memo.output!.publicPath = `${protocol}://${localIpAddress}:${port}/`;
     }
     return memo;
   });
@@ -59,14 +62,14 @@ export default function(api: IApi, options: Options) {
   // source-map 跨域设置
   if (process.env.NODE_ENV === 'development' && port) {
     // 变更 webpack-dev-server websocket 默认监听地址
-    process.env.SOCKET_SERVER = `${protocol}://localhost:${port}/`;
+    process.env.SOCKET_SERVER = `${protocol}://${localIpAddress}:${port}/`;
     api.chainWebpackConfig(memo => {
       // 禁用 devtool，启用 SourceMapDevToolPlugin
       memo.devtool(false);
       memo.plugin('source-map').use(webpack.SourceMapDevToolPlugin, [
         {
           namespace: pkgName,
-          append: `\n//# sourceMappingURL=${protocol}://localhost:${port}/[url]`,
+          append: `\n//# sourceMappingURL=${protocol}://${localIpAddress}:${port}/[url]`,
           filename: '[file].map',
         },
       ]);


### PR DESCRIPTION
> ### 为什么要这么改？

主要目的是为了解决本地开发的时候可以共享项目运行地址给其他人查看

> ### 场景

* 场景 1
项目需要对 IE 进行兼容性处理，但日常开发都是在 mac 上进行的，这时候需要在另外一台 windows 电脑上访问开发机的地址，但是 qiankun slave 中对静态资源的域统一为 `localhost`,
windows 在访问的时候在它系统中找不到 `localhost` 下的服务，导致没办法操作

* 场景 2
前后端在联调的时候，后端想要访问前端的页面对部分接口进行测试，同样存在无法找到 `localhost` 的服务
