### PR TITLE
:sparkles: 支持用户已手动配置过应用路由的场景

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ export default {
 | --- | --- | --- | --- | --- |
 | name | 子应用唯一 id | string | 是 |  |
 | entry | 子应用 html 地址 | string \| { script: string[], styles: [] } | 是 |  |
-| base | 子应用路由前缀，通常跟子应用的 [base 配置](https://umijs.org/config/#base) 一致，框架会以这个配置作为前缀判断是否激活当前应用 | string \| string[] | 是 |  |
+| base | 子应用路由前缀，通常跟子应用的 [base 配置](https://umijs.org/config/#base) 一致，框架会以这个配置作为前缀判断是否激活当前应用，支持配置一组前缀 | string \| string[] | 是 |  |
 | history | [umi history mode](https://umijs.org/config/#history) | string | 否 | 主应用 history 配置 |
 | mountElementId | 子应用挂载到主应用的哪个 id 节点上（注意不要跟子应用的 mountElementId 一致） | string | 否 | root-subapp |
 | props | 主应用传递给子应用的数据 | object | 否 | {} |

--- a/examples/master/models/base.js
+++ b/examples/master/models/base.js
@@ -32,7 +32,7 @@ export default {
       });
 
       // 模拟手动控制 qiankun 启动时机的场景, 需要 defer 配置为 true
-      setTimeout(qiankunStart, 1000);
+      setTimeout(qiankunStart, 200);
     },
   },
 

--- a/src/__tests__/common.test.ts
+++ b/src/__tests__/common.test.ts
@@ -7,6 +7,8 @@ import { testPathWithPrefix } from '../common';
 
 it('testPathPrefix', () => {
   // browser history
+  expect(testPathWithPrefix('/js', '/')).toBeFalsy();
+
   expect(testPathWithPrefix('/js', '/js')).toBeTruthy();
   expect(testPathWithPrefix('/js', '/jss')).toBeFalsy();
   expect(testPathWithPrefix('/js', '/js/')).toBeTruthy();


### PR DESCRIPTION
用户已配置 app base 相应的路由时不再自动生成 mock 路由

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/umijs/umi-plugin-qiankun/46)
<!-- Reviewable:end -->
