### PR TITLE
fix: @babel/runtime 版本不兼容导致报错

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "test": "umi-test"
   },
   "dependencies": {
-    "@babel/runtime": "^7.4.5",
+    "@babel/runtime": "~7.4.5",
     "address": "^1.1.2",
     "lodash": "^4.17.15",
     "path-to-regexp": "^1.7.0",


### PR DESCRIPTION
> "@babel/runtime": "^7.4.5", 
如果项目匹配到了 @babel/runtime 7.8.4 版本，运行会抛出异常

> Module not found: Can't resolve '@babel/runtime/helpers/createForOfIteratorHelper'

修复： 升级 @babel/runtime 到最新版本，或保持 7.4.5 低版本