### PR TITLE
fix: 修改umi dev启动环境变量不起作用

### DIFF
--- a/src/slave/index.ts
+++ b/src/slave/index.ts
@@ -93,7 +93,9 @@ export default function(api: IApi, options: Options) {
   // source-map 跨域设置
   if (process.env.NODE_ENV === 'development' && port) {
     // 变更 webpack-dev-server websocket 默认监听地址
-    process.env.SOCKET_SERVER = `${protocol}://${localIpAddress}:${port}/`;
+    if(typeof process.env.SOCKET_SERVER === 'undefined') {
+      process.env.SOCKET_SERVER = `${protocol}://${localIpAddress}:${port}/`;
+    }
     api.chainWebpackConfig(memo => {
       // 禁用 devtool，启用 SourceMapDevToolPlugin
       memo.devtool(false);


### PR DESCRIPTION
umi 启动时设置SOCKET_SERVER不起作用
 "start": "SOCKET_SERVER='' umi dev"
